### PR TITLE
Use @compileError to catch error at comptime

### DIFF
--- a/src/tracy.zig
+++ b/src/tracy.zig
@@ -157,8 +157,8 @@ pub inline fn plot(comptime T: type, comptime name: [:0]const u8, value: T) void
     const type_info = @typeInfo(T);
     switch (type_info) {
         .Int => |int_type| {
-            if (int_type.bits > 64) @panic("Too large int to plot");
-            if (int_type.signedness == .unsigned and int_type.bits > 63) @panic("Too large unsigned int to plot");
+            if (int_type.bits > 64) @compileError("Too large int to plot");
+            if (int_type.signedness == .unsigned and int_type.bits > 63) @compileError("Too large unsigned int to plot");
             c.___tracy_emit_plot_int(name, value);
         },
         .Float => |float_type| {
@@ -167,10 +167,10 @@ pub inline fn plot(comptime T: type, comptime name: [:0]const u8, value: T) void
             } else if (float_type.bits <= 64) {
                 c.___tracy_emit_plot(name, value);
             } else {
-                @panic("Too large float to plot");
+                @compileError("Too large float to plot");
             }
         },
-        else => @panic("Unsupported plot value type"),
+        else => @compileError("Unsupported plot value type"),
     }
 }
 


### PR DESCRIPTION
In old version @panic cause program to compile fine just to crash the moment `plot` function is called.